### PR TITLE
Remove deprecated 'root' object that throws a deprecation warning in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ describe('module', function() {
 });
 ```
 
+Changelog
+-------
+
+* 0.1.1 Removed use of deprecated `root` that throws a warning in Node 6.
+
+* 0.1.0 Initial release
+
 License
 -------
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var sync = require('synchronize');
 
 var fakeContext = {};
 var context =
-  typeof root !== 'undefined' ? root :
   typeof global !== 'undefined' ? global :
   typeof window !== 'undefined' ? window : fakeContext;
 


### PR DESCRIPTION
…Node 6. Fortunately its replacement, `global`, has been available since Node v0.1.27 (https://nodejs.org/api/globals.html#globals_global).
